### PR TITLE
Captions: Added Wildcards, Improved handling and highlighting of combined tags

### DIFF
--- a/caption/caption_bubbles.py
+++ b/caption/caption_bubbles.py
@@ -49,7 +49,7 @@ class CaptionBubbles(ReorderWidget):
     def updateBubbles(self):
         oldBubbles: list[Bubble] = [bubble for bubble in self.getBubbles()]
 
-        colors = self.ctx.groups.getCaptionColors()
+        colors = self.ctx.highlight.colors
         i = -1
         for i, caption in enumerate(self.text.split(self.separator)):
             caption = caption.strip()

--- a/caption/caption_bubbles.py
+++ b/caption/caption_bubbles.py
@@ -2,6 +2,7 @@ from PySide6 import QtWidgets, QtGui
 from PySide6.QtCore import Qt, Signal, Slot
 import lib.qtlib as qtlib
 from ui.flow_layout import FlowLayout, ReorderWidget
+from .caption_context import CaptionContext
 
 # TODO: Nested bubbles for expressions like: (blue (starry:0.8) sky:1.2)
 
@@ -13,13 +14,12 @@ class CaptionBubbles(ReorderWidget):
     dropped = Signal(str)
     clicked = Signal(int)
 
-    def __init__(self, context, showWeights=True, showRemove=False, editable=True):
+    def __init__(self, context: CaptionContext, showWeights=True, showRemove=False, editable=True):
         super().__init__()
         self.dataCallback = lambda widget: widget.text
         self.receivedDrop.connect(self._onDrop)
 
-        from .caption_container import CaptionContext
-        self.ctx: CaptionContext = context
+        self.ctx = context
 
         self.text = ""
         self.separator = ','

--- a/caption/caption_bubbles.py
+++ b/caption/caption_bubbles.py
@@ -5,6 +5,9 @@ from ui.flow_layout import FlowLayout, ReorderWidget
 
 # TODO: Nested bubbles for expressions like: (blue (starry:0.8) sky:1.2)
 
+# TODO: Colors for combined tags
+
+
 class CaptionBubbles(ReorderWidget):
     remove = Signal(int)
     dropped = Signal(str)

--- a/caption/caption_bubbles.py
+++ b/caption/caption_bubbles.py
@@ -47,9 +47,8 @@ class CaptionBubbles(ReorderWidget):
                 yield widget
 
     def updateBubbles(self):
-        oldBubbles: list[Bubble] = [bubble for bubble in self.getBubbles()]
+        oldBubbles = list[Bubble](self.getBubbles())
 
-        colors = self.ctx.highlight.colors
         i = -1
         for i, caption in enumerate(self.text.split(self.separator)):
             caption = caption.strip()
@@ -62,7 +61,7 @@ class CaptionBubbles(ReorderWidget):
                 bubble.setFocusProxy(self)
                 self.layout().addWidget(bubble)
 
-            color = colors.get(caption)
+            color = self._getBubbleColor(caption)
             if color is None:
                 color = qtlib.COLOR_BUBBLE_HOVER if self.ctx.container.isHovered(caption) else qtlib.COLOR_BUBBLE_BLACK
 
@@ -72,6 +71,19 @@ class CaptionBubbles(ReorderWidget):
 
         for i in range(i+1, len(oldBubbles)):
             oldBubbles[i].deleteLater()
+
+    def _getBubbleColor(self, caption: str) -> str | None:
+        highlight = self.ctx.highlight
+        if color := highlight.colors.get(caption):
+            return color
+
+        captionWords = [word for word in caption.split(" ") if word]
+        matchFormats = highlight.matchNode.match(captionWords)
+        if len(matchFormats) != len(captionWords):
+            return None
+
+        colors = set(format.color for format in matchFormats.values())
+        return next(iter(colors)) if len(colors) == 1 else None
 
 
     def resizeEvent(self, event):

--- a/caption/caption_conditionals.py
+++ b/caption/caption_conditionals.py
@@ -149,6 +149,7 @@ class ConditionalRule(QtWidgets.QWidget):
         layout.setContentsMargins(3, 5, 5, 0)
         layout.setSpacing(4)
 
+        # First Column, Drag Handle
         col = 0
         layout.setColumnStretch(col, 0)
         layout.setColumnMinimumWidth(col, 10)
@@ -156,7 +157,7 @@ class ConditionalRule(QtWidgets.QWidget):
 
         # Left Column
         col = 1
-        layout.setColumnStretch(col, 10)
+        layout.setColumnStretch(col, 1)
         layout.addLayout(self.conditionLayout, 0, col, 2, 1, Qt.AlignmentFlag.AlignTop)
 
         btnAddCondition = QtWidgets.QPushButton("✚ Add Condition")
@@ -165,37 +166,40 @@ class ConditionalRule(QtWidgets.QWidget):
 
         # Right Column
         col = 2
-        colspanRight = 3
-        layout.setColumnStretch(col, 0)
-        layout.setColumnStretch(col+1, 10)
-        layout.setColumnStretch(col+2, 0)
+        layout.setColumnStretch(col, 1)
 
-        self.lblExpression = QtWidgets.QLabel("Expression:")
-        layout.addWidget(self.lblExpression, 0, col)
-
-        self.txtExpression = QtWidgets.QLineEdit()
-        self.txtExpression.setPlaceholderText("and")
-        qtlib.setMonospace(self.txtExpression)
-        self.txtExpression.textChanged.connect(self._onExpressionChanged)
-        layout.addWidget(self.txtExpression, 0, col+1)
-
-        btnRemoveRule = QtWidgets.QPushButton("Remove Rule")
-        btnRemoveRule.clicked.connect(lambda: self.removeClicked.emit(self))
-        layout.addWidget(btnRemoveRule, 0, col+2)
-
-        layout.addLayout(self.actionLayout, 1, col, 1, colspanRight, Qt.AlignmentFlag.AlignTop)
+        layout.addLayout(self._buildRightTopRow(), 0, col)
+        layout.addLayout(self.actionLayout, 1, col, Qt.AlignmentFlag.AlignTop)
 
         btnAddAction = QtWidgets.QPushButton("✚ Add Action")
         btnAddAction.clicked.connect(lambda: self.addRuleAction())
-        layout.addWidget(btnAddAction, 2, col, 1, colspanRight)
+        layout.addWidget(btnAddAction, 2, col)
 
         layout.setRowMinimumHeight(3, 3)
 
         separatorLine = QtWidgets.QFrame()
         separatorLine.setFrameStyle(QtWidgets.QFrame.Shape.HLine | QtWidgets.QFrame.Shadow.Sunken)
-        layout.addWidget(separatorLine, 4, 0, 1, colspanRight+2)
+        layout.addWidget(separatorLine, 4, 0, 1, 3)
 
         self.setLayout(layout)
+
+    def _buildRightTopRow(self):
+        layout = QtWidgets.QHBoxLayout()
+
+        self.lblExpression = QtWidgets.QLabel("Expression:")
+        layout.addWidget(self.lblExpression, 0)
+
+        self.txtExpression = QtWidgets.QLineEdit()
+        self.txtExpression.setPlaceholderText("and")
+        qtlib.setMonospace(self.txtExpression)
+        self.txtExpression.textChanged.connect(self._onExpressionChanged)
+        layout.addWidget(self.txtExpression, 1)
+
+        btnRemoveRule = QtWidgets.QPushButton("Remove Rule")
+        btnRemoveRule.clicked.connect(lambda: self.removeClicked.emit(self))
+        layout.addWidget(btnRemoveRule, 0)
+
+        return layout
 
 
     @Slot()

--- a/caption/caption_container.py
+++ b/caption/caption_container.py
@@ -346,11 +346,10 @@ class CaptionContainer(QtWidgets.QWidget):
     def updateSelectionState(self, captionText: str, force=False):
         separator = self.captionSeparator.strip()
         captions = [ cap for c in captionText.split(separator) if (cap := c.strip()) ]
-        captionSet = set(captions)
 
         self.ctx.conditionals.updateState(captions)
-        self.ctx.groups.updateSelectedState(captionSet, force)
-        self.ctx.focus.updateSelectionState(captionSet)
+        self.ctx.groups.updateSelectedState(captions, force)
+        self.ctx.focus.updateSelectionState(set(captions))
 
     @Slot()
     def _forceUpdateGroupSelection(self):

--- a/caption/caption_container.py
+++ b/caption/caption_container.py
@@ -28,17 +28,18 @@ class CaptionContext(QtWidgets.QTabWidget):
     def __init__(self, container: CaptionContainer, tab: ImgTab):
         super().__init__()
         self.container = container
-        self.text = container.txtCaption
         self.tab = tab
 
         self._cachedRulesProcessor: CaptionRulesProcessor | None = None
         self.controlUpdated.connect(self._invalidateRulesProcessor) # First Slot for controlUpdated
 
-        self.highlight    = CaptionHighlight(self)
         self.settings     = CaptionSettings(self)
         self.groups       = CaptionGroups(self)
         self.conditionals = CaptionConditionals(self)
         self.generate     = CaptionGenerate(self)
+
+        self.text         = CaptionTextEdit(self)
+        self.highlight    = CaptionHighlight(self)
 
         from .caption_focus import CaptionFocus
         self.focus = CaptionFocus(container, self)
@@ -79,14 +80,14 @@ class CaptionContainer(QtWidgets.QWidget):
     def __init__(self, tab):
         super().__init__()
 
-        self.txtCaption = CaptionTextEdit()
-        self.txtCaption.textChanged.connect(self._onCaptionEdited)
-        self.txtCaption.needsRulesApplied.connect(self.applyRulesIfAuto)
-
         self.captionCache = CaptionCache(tab.filelist)
         self.captionSeparator = ', '
 
         self.ctx = CaptionContext(self, tab)
+
+        self.txtCaption = self.ctx.text
+        self.txtCaption.textChanged.connect(self._onCaptionEdited)
+
         self._menu = CaptionMenu(self, self.ctx)
         self._build(self.ctx)
 
@@ -438,9 +439,8 @@ class CaptionContainer(QtWidgets.QWidget):
 
 
     @Slot()
-    def _onSeparatorChanged(self, separator):
+    def _onSeparatorChanged(self, separator: str):
         self.captionSeparator = separator
-        self.txtCaption.separator = separator
         self.bubbles.separator = separator
         self._onControlUpdated()
 

--- a/caption/caption_container.py
+++ b/caption/caption_container.py
@@ -550,14 +550,14 @@ class CaptionContainer(QtWidgets.QWidget):
         rulesProcessor.setup(self.ctx.settings.prefix, self.ctx.settings.suffix, self.captionSeparator, removeDup, sortCaptions)
         rulesProcessor.setSearchReplacePairs(self.ctx.settings.searchReplacePairs)
         rulesProcessor.setBannedCaptions(self.ctx.settings.bannedCaptions)
-        rulesProcessor.setCaptionGroups( (group.captions, group.exclusivity, group.combineTags) for group in self.ctx.groups.groups )
+        rulesProcessor.setCaptionGroups( (group.captionsExpandWildcards, group.exclusivity, group.combineTags) for group in self.ctx.groups.groups )
         rulesProcessor.setConditionalRules(self.ctx.conditionals.getFilterRules())
         return rulesProcessor
 
 
     @Slot()
     def saveCaption(self):
-        # Skip to next file when saving succeds and skip-on-save is enabled. Don't loop.
+        # Skip to next file when saving succeeds and skip-on-save is enabled. Don't loop.
         filelist = self.ctx.tab.filelist
         if self.saveCaptionNoSkip() and self.chkSkipOnSave.isChecked() and not filelist.isLastFile():
             filelist.setNextFile()

--- a/caption/caption_container.py
+++ b/caption/caption_container.py
@@ -4,76 +4,12 @@ from PySide6.QtCore import Qt, Signal, Slot, QTimer
 from lib import qtlib
 from lib.filelist import DataKeys
 from lib.captionfile import FileTypeSelector
-from ui.tab import ImgTab
 from config import Config
+from .caption_context import CaptionContext
 from .caption_menu import CaptionMenu, RulesLoadMode
 from .caption_bubbles import CaptionBubbles
 from .caption_text import CaptionTextEdit
-from .caption_highlight import CaptionHighlight
 from .caption_filter import CaptionRulesProcessor
-from .caption_settings import CaptionSettings
-from .caption_groups import CaptionGroups
-from .caption_conditionals import CaptionConditionals
-from .caption_generate import CaptionGenerate
-from .caption_list import CaptionList
-
-
-class CaptionContext(QtWidgets.QTabWidget):
-    captionEdited       = Signal(str)
-    separatorChanged    = Signal(str)
-    controlUpdated      = Signal()
-    needsRulesApplied   = Signal()
-
-
-    def __init__(self, container: CaptionContainer, tab: ImgTab):
-        super().__init__()
-        self.container = container
-        self.tab = tab
-
-        self._cachedRulesProcessor: CaptionRulesProcessor | None = None
-        self.controlUpdated.connect(self._invalidateRulesProcessor) # First Slot for controlUpdated
-
-        self.settings     = CaptionSettings(self)
-        self.groups       = CaptionGroups(self)
-        self.conditionals = CaptionConditionals(self)
-        self.generate     = CaptionGenerate(self)
-
-        self.text         = CaptionTextEdit(self)
-        self.highlight    = CaptionHighlight(self)
-
-        from .caption_focus import CaptionFocus
-        self.focus = CaptionFocus(container, self)
-
-        self.addTab(self.settings, "Rules")
-        self.addTab(self.groups, "Groups")
-        self.addTab(self.conditionals, "Conditionals")
-        self.addTab(self.focus, "Focus")
-        #self.addTab(QtWidgets.QWidget(), "Folder Overrides") # Let variables from json override settings?
-        self.addTab(self.generate, "Generate")
-        self.addTab(CaptionList(self), "List")
-
-        self._activeWidget = None
-        self.currentChanged.connect(self.onTabChanged)
-        self.onTabChanged(0)
-
-    @Slot()
-    def onTabChanged(self, index: int):
-        if self._activeWidget:
-            self._activeWidget.onTabDisabled()
-
-        if widget := self.widget(index):
-            self._activeWidget = widget
-            widget.onTabEnabled()
-
-    @Slot()
-    def _invalidateRulesProcessor(self):
-        self._cachedRulesProcessor = None
-
-    def rulesProcessor(self) -> CaptionRulesProcessor:
-        if not self._cachedRulesProcessor:
-            self._cachedRulesProcessor = self.container.createRulesProcessor()
-        return self._cachedRulesProcessor
-
 
 
 class CaptionContainer(QtWidgets.QWidget):

--- a/caption/caption_container.py
+++ b/caption/caption_container.py
@@ -368,7 +368,6 @@ class CaptionContainer(QtWidgets.QWidget):
 
     @Slot()
     def applyRules(self):
-        # FIXME: The preview is made after applying the rules to the text. This can change the sorting of combined tags.
         rulesProcessor = self.createRulesProcessor()
         text = self.txtCaption.getCaption()
         textNew = rulesProcessor.process(text)

--- a/caption/caption_container.py
+++ b/caption/caption_container.py
@@ -80,6 +80,7 @@ class CaptionContainer(QtWidgets.QWidget):
         super().__init__()
 
         self.txtCaption = CaptionTextEdit()
+        self.txtCaption.textChanged.connect(self._onCaptionEdited)
         self.txtCaption.needsRulesApplied.connect(self.applyRulesIfAuto)
 
         self.captionCache = CaptionCache(tab.filelist)
@@ -138,7 +139,6 @@ class CaptionContainer(QtWidgets.QWidget):
 
         row += 1
         qtlib.setMonospace(self.txtCaption, 1.2)
-        self.txtCaption.textChanged.connect(self._onCaptionEdited)
         splitter.addWidget(self.txtCaption)
         splitter.setStretchFactor(row, 1)
 

--- a/caption/caption_context.py
+++ b/caption/caption_context.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+from typing import Iterable
+from PySide6 import QtWidgets
+from PySide6.QtCore import Signal, Slot
+from ui.tab import ImgTab
+from .caption_highlight import CaptionHighlight, HighlightDataSource, CaptionGroupData
+from .caption_filter import CaptionRulesProcessor
+from .caption_settings import CaptionSettings
+from .caption_groups import CaptionGroups
+from .caption_list import CaptionList
+
+
+class CaptionContext(QtWidgets.QTabWidget):
+    captionEdited       = Signal(str)
+    separatorChanged    = Signal(str)
+    controlUpdated      = Signal()
+    needsRulesApplied   = Signal()
+
+
+    def __init__(self, container, tab: ImgTab):
+        super().__init__()
+        self.tab = tab
+
+        self._cachedRulesProcessor: CaptionRulesProcessor | None = None
+        self.controlUpdated.connect(self._invalidateRulesProcessor) # First Slot for controlUpdated
+
+        from .caption_container import CaptionContainer
+        self.container: CaptionContainer = container
+
+        self.settings = CaptionSettings(self)
+        self.groups = CaptionGroups(self)
+
+        from .caption_conditionals import CaptionConditionals
+        self.conditionals = CaptionConditionals(self)
+
+        from .caption_focus import CaptionFocus
+        self.focus = CaptionFocus(container, self)
+
+        from .caption_generate import CaptionGenerate
+        self.generate = CaptionGenerate(self)
+
+        from .caption_text import CaptionTextEdit
+        self.text = CaptionTextEdit(self)
+        self.highlight = CaptionHighlight(CaptionContextDataSource(self))
+
+        self.addTab(self.settings, "Rules")
+        self.addTab(self.groups, "Groups")
+        self.addTab(self.conditionals, "Conditionals")
+        self.addTab(self.focus, "Focus")
+        #self.addTab(QtWidgets.QWidget(), "Folder Overrides") # Let variables from json override settings?
+        self.addTab(self.generate, "Generate")
+        self.addTab(CaptionList(self), "List")
+
+        self._activeWidget = None
+        self.currentChanged.connect(self.onTabChanged)
+        self.onTabChanged(0)
+
+    @Slot()
+    def onTabChanged(self, index: int):
+        if self._activeWidget:
+            self._activeWidget.onTabDisabled()
+
+        if widget := self.widget(index):
+            self._activeWidget = widget
+            widget.onTabEnabled()
+
+    @Slot()
+    def _invalidateRulesProcessor(self):
+        self._cachedRulesProcessor = None
+
+    def rulesProcessor(self) -> CaptionRulesProcessor:
+        if not self._cachedRulesProcessor:
+            self._cachedRulesProcessor = self.container.createRulesProcessor()
+        return self._cachedRulesProcessor
+
+
+
+class CaptionContextDataSource(HighlightDataSource):
+    def __init__(self, context: CaptionContext):
+        super().__init__()
+        self.ctx: CaptionContext = context
+
+    def connectClearCache(self, slot: Slot):
+        self.ctx.controlUpdated.connect(slot)
+
+    def isHovered(self, caption: str) -> bool:
+        return self.ctx.container.isHovered(caption)
+
+    def getFocusSet(self) -> set[str]:
+        return self.ctx.focus.getFocusSet()
+
+    def getBanned(self) -> Iterable[str]:
+        return self.ctx.settings.bannedCaptions
+
+    def getGroups(self) -> Iterable[CaptionGroupData]:
+        return (
+            CaptionGroupData(group.captionsExpandWildcards, group.charFormat, group.color)
+            for group in self.ctx.groups.groups
+        )

--- a/caption/caption_filter.py
+++ b/caption/caption_filter.py
@@ -56,7 +56,7 @@ class SortCaptionFilter(CaptionFilter):
         i = 1  # Only truthy values
         for group in captionGroups:
             for caption in group:
-                self.matcherNode.add(caption.split(" "), i)
+                self.matcherNode.add(caption, i)
                 self.captionOrder[caption] = i
                 i += 1
 
@@ -223,7 +223,7 @@ class TagCombineFilter(CaptionFilter):
 
         for cap in (cap for c in captions if (cap := c.strip())):
             words = [word for word in cap.split(" ") if word]
-            self.matcherNode.add(words, True)
+            self.matcherNode.addWords(words, True)
 
             lastWord = words[-1]
             groupIndex = groupWords.get(lastWord)
@@ -385,7 +385,7 @@ class PrefixSuffixFilter:
         self.prefix = ""
         self.suffix = ""
 
-    def setup(self, prefix, suffix) -> None:
+    def setup(self, prefix: str, suffix: str) -> None:
         self.prefix = prefix
         self.suffix = suffix
 
@@ -452,7 +452,6 @@ class CaptionRulesProcessor:
         self.conditionalsFilter.setup(rules, self.separator)
 
 
-    # TODO: Sort combined tags. Split all tags of combine-groups first? But check if all tags are part of same group
     def process(self, text: str) -> str:
         text = self.replaceFilter.filterText(text)
         captions = [c.strip() for c in text.split(self.separator.strip())]
@@ -470,12 +469,6 @@ class CaptionRulesProcessor:
         captions = self.banFilter.filterCaptions(captions)
 
         captions = self.conditionalsFilter.filterCaptions(captions)
-
-        # TODO: Check if changing this order has side effects
-        # if self.removeDup:
-        #     # Remove subsets after banning, so no tags are wrongly merged and removed with banned tags.
-        #     captions = self.subsetFilter.filterCaptions(captions)
-        #     captions = self.dupFilter.filterCaptions(captions) # SubsetFilter won't remove exact duplicates
 
         # Sort before combine filter so order inside group will define order of words inside combined tag
         if self.sortCaptions:

--- a/caption/caption_focus.py
+++ b/caption/caption_focus.py
@@ -3,7 +3,9 @@ from PySide6.QtCore import Qt, Slot, Signal, QObject, QEvent, QTimer
 import lib.qtlib as qtlib
 from ui.flow_layout import FlowLayout
 from .caption_tab import CaptionTab
-from .caption_container import CaptionContainer, CaptionContext
+from .caption_context import CaptionContext
+from .caption_container import CaptionContainer
+
 
 # - As tab in Caption Window
 # - Overrides current colors, highlights defined tags

--- a/caption/caption_focus.py
+++ b/caption/caption_focus.py
@@ -144,7 +144,7 @@ class CaptionFocus(CaptionTab):
             bubble.setColor(bubble.groupColor if exists else qtlib.COLOR_BUBBLE_BLACK)
 
     def _updateSelectionState(self):
-        captions = self.container.getCaption().split(self.separator.strip())
+        captions = self.ctx.text.getCaption().split(self.separator.strip())
         captionSet = { cap for c in captions if (cap := c.strip()) }
         self.updateSelectionState(captionSet)
 
@@ -158,7 +158,7 @@ class CaptionFocus(CaptionTab):
         if not text:
             return
 
-        colors = self.ctx.groups.getCaptionColors()
+        colors = self.ctx.highlight.colors
 
         for i, tag in enumerate(text.split(self.separator.strip())):
             tag = tag.strip()
@@ -204,7 +204,7 @@ class CaptionFocus(CaptionTab):
 
         captions = []
         exists = False
-        text = self.container.getCaption()
+        text = self.ctx.text.getCaption()
         if text:
             for current in text.split(self.separator.strip()):
                 current = current.strip()
@@ -219,7 +219,7 @@ class CaptionFocus(CaptionTab):
 
         newText = self.separator.join(captions)
         if newText != text:
-            self.container.setCaption(newText)
+            self.ctx.text.setCaption(newText)
             self.ctx.needsRulesApplied.emit()
 
         # Always save, even when text is unchanged.

--- a/caption/caption_generate.py
+++ b/caption/caption_generate.py
@@ -1,4 +1,5 @@
 import os, re, traceback
+from enum import Enum
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt, Slot, Signal, QRunnable, QObject, QSignalBlocker
 from infer import Inference, InferencePresetWidget, TagPresetWidget, PromptWidget, PromptsHighlighter, InferenceProcess
@@ -7,6 +8,12 @@ from lib.filelist import DataKeys
 import lib.qtlib as qtlib
 from config import Config
 from .caption_tab import CaptionTab
+
+
+class ApplyMode(Enum):
+    Append  = "append"
+    Prepend = "prepend"
+    Replace = "replace"
 
 
 class CaptionGenerate(CaptionTab):
@@ -71,9 +78,9 @@ class CaptionGenerate(CaptionTab):
         layout.addWidget(self.tagSettings, row, 0, 2, 2)
 
         self.cboMode = QtWidgets.QComboBox()
-        self.cboMode.addItem("Append")
-        self.cboMode.addItem("Prepend")
-        self.cboMode.addItem("Replace")
+        self.cboMode.addItem("Append", ApplyMode.Append)
+        self.cboMode.addItem("Prepend", ApplyMode.Prepend)
+        self.cboMode.addItem("Replace", ApplyMode.Replace)
         layout.addWidget(self.cboMode, row, 3)
 
         self.cboCapTag = QtWidgets.QComboBox()
@@ -120,7 +127,7 @@ class CaptionGenerate(CaptionTab):
 
     def updatePreview(self, prompt: str):
         if self._hasRefinedVar:
-            self._parser.updateRefinedCaption(self.ctx.container.getCaption())
+            self._parser.updateRefinedCaption(self.ctx.text.getCaption())
 
         preview, varPositions = self._parser.parseWithPositions(prompt)
         self.txtPromptPreview.setPlainText(preview)
@@ -176,24 +183,42 @@ class CaptionGenerate(CaptionTab):
         self.statusBar.showMessage(message)
 
     @Slot()
-    def onGenerated(self, imgPath, text):
+    def onGenerated(self, imgPath: str, generatedText: str):
         self.btnGenerate.setEnabled(True)
 
-        if not text:
+        if not generatedText:
             self.statusBar.showColoredMessage("Finished with empty result", False, 0)
             return
+
         self.statusBar.showColoredMessage("Done", True)
 
         filelist = self.ctx.tab.filelist
         if imgPath == filelist.getCurrentFile():
-            mode = self.cboMode.currentText()
-            self.ctx.captionGenerated.emit(text, mode)
+            text = self._addToCaption(generatedText, self.ctx.text.getCaption())
+            self.ctx.text.setCaption(text)
+            self.ctx.needsRulesApplied.emit()
         else:
+            existingText = filelist.getData(imgPath, DataKeys.Caption)
+            if existingText is None:
+                existingText = self.ctx.container.srcSelector.loadCaption(imgPath)
+
+            text = self._addToCaption(generatedText, existingText)
             filelist.setData(imgPath, DataKeys.Caption, text)
             filelist.setData(imgPath, DataKeys.CaptionState, DataKeys.IconStates.Changed)
 
+    def _addToCaption(self, generatedText: str, existingText: str | None) -> str:
+        if not existingText:
+            return generatedText
+
+        match self.cboMode.currentData():
+            case ApplyMode.Append:  return f"{existingText}{os.linesep}{generatedText}"
+            case ApplyMode.Prepend: return f"{generatedText}{os.linesep}{existingText}"
+            case ApplyMode.Replace: return generatedText
+            case _:
+                raise ValueError("Invalid mode")
+
     @Slot()
-    def onFail(self, errorMsg):
+    def onFail(self, errorMsg: str):
         self.btnGenerate.setEnabled(True)
         self.statusBar.showColoredMessage(errorMsg, False, 0)
 
@@ -220,7 +245,7 @@ class CurrentVariableParser(TemplateVariableParser):
     def _getImgProperties(self, var: str) -> str | None:
         match var:
             case self.CURRENT_VAR_NAME:
-                return self.ctx.container.getCaption()
+                return self.ctx.text.getCaption()
             case self.REFINED_VAR_NAME:
                 return self.refinedCaption
 

--- a/caption/caption_generate.py
+++ b/caption/caption_generate.py
@@ -8,6 +8,7 @@ from lib.filelist import DataKeys
 import lib.qtlib as qtlib
 from config import Config
 from .caption_tab import CaptionTab
+from .caption_context import CaptionContext
 
 
 class ApplyMode(Enum):
@@ -232,12 +233,10 @@ class CurrentVariableParser(TemplateVariableParser):
     REFINED_VAR_PATTERN = re.compile(r'{{.*refined.*}}')
 
 
-    def __init__(self, context, imgPath: str = None):
+    def __init__(self, context: CaptionContext, imgPath: str = None):
         super().__init__(imgPath)
+        self.ctx = context
         self.refinedCaption = ""
-
-        from .caption_container import CaptionContext
-        self.ctx: CaptionContext = context
 
     def updateRefinedCaption(self, caption: str):
         self.refinedCaption = self.ctx.rulesProcessor().process(caption)

--- a/caption/caption_highlight.py
+++ b/caption/caption_highlight.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Iterable
 from PySide6 import QtGui, QtWidgets
 from PySide6.QtCore import Slot, QSignalBlocker
 from lib import qtlib, util, colors
@@ -275,3 +276,13 @@ class MatcherNode:
     def split(self, words: list[str]) -> list[str]:
         groups = self.splitWords(words)
         return [" ".join(groupWords) for groupWords in groups]
+
+    def matchSplitCaptions(self, captions: Iterable[str]) -> set[str]:
+        captionSet = set[str]()
+        for cap in captions:
+            if matchSplit := self.split(cap.split(" ")):
+                captionSet.update(matchSplit)
+            else:
+                captionSet.add(cap)
+
+        return captionSet

--- a/caption/caption_highlight.py
+++ b/caption/caption_highlight.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+from PySide6 import QtGui, QtWidgets
+from PySide6.QtCore import Slot, QSignalBlocker
+from lib import qtlib, util, colors
+from lib.util import stripCountPadding
+
+
+COLOR_FOCUS_DEFAULT = "#901313"
+COLOR_FOCUS_BAN     = "#686868"
+
+
+class CaptionHighlight:
+    def __init__(self, context):
+        from .caption_container import CaptionContext
+        self.ctx: CaptionContext = context
+        self.ctx.controlUpdated.connect(self.clearCache)
+
+        self._cachedColors: dict[str, str] | None = None
+        self._cachedCharFormats: dict[str, QtGui.QTextCharFormat] | None = None
+        self._cachedCombineFormats: dict[str, CombineFormat] | None = None
+
+        self._bannedFormat = QtGui.QTextCharFormat()
+        self._bannedFormat.setForeground(QtGui.QColor.fromHsvF(0, 0, 0.5))
+
+        self._focusFormat = QtGui.QTextCharFormat()
+        self._focusFormat.setForeground(qtlib.getHighlightColor(COLOR_FOCUS_DEFAULT))
+
+
+    @property
+    def colors(self) -> dict[str, str]:
+        if not self._cachedColors:
+            self.update()
+        return self._cachedColors
+
+    @property
+    def charFormats(self) -> dict[str, QtGui.QTextCharFormat]:
+        if not self._cachedCharFormats:
+            self.update()
+        return self._cachedCharFormats
+
+    @property
+    def combineFormats(self) -> dict[str, CombineFormat]:
+        if not self._cachedCombineFormats:
+            self.updateCombineFormats()
+        return self._cachedCombineFormats
+
+
+    def highlight(self, text: str, separator: str, txtWidget: QtWidgets.QPlainTextEdit):
+        separator = separator.strip()
+
+        formats = self.charFormats
+        wordFormatMap = self.combineFormats
+
+        with QSignalBlocker(txtWidget):
+            cursor = txtWidget.textCursor()
+            cursor.setPosition(0)
+            cursor.movePosition(QtGui.QTextCursor.MoveOperation.End, QtGui.QTextCursor.MoveMode.KeepAnchor)
+            cursor.setCharFormat(QtGui.QTextCharFormat())
+
+            start = 0
+
+            for caption in text.split(separator):
+                captionStrip, padLeft, padRight = stripCountPadding(caption)
+                start += padLeft
+
+                if format := formats.get(captionStrip):
+                    self._highlightPart(cursor, format, start, len(captionStrip))
+                elif self.ctx.container.isHovered(captionStrip):
+                    format = QtGui.QTextCharFormat()
+                    format.setFontUnderline(True)
+                    self._highlightPart(cursor, format, start, len(captionStrip))
+
+                # Try highlighting combined words
+                else:
+                    captionWords = captionStrip.split(" ")
+                    lastWord = captionWords[-1]
+                    pos = start
+
+                    if (combineFormat := wordFormatMap.get(lastWord)) and (groupFormat := combineFormat.getGroupFormat(captionWords)):
+                        for word in captionWords[:-1]:
+                            if word in groupFormat.words:
+                                self._highlightPart(cursor, groupFormat.format, pos, len(word))
+                            pos += len(word) + 1
+
+                        self._highlightPart(cursor, groupFormat.format, pos, len(lastWord))
+
+                    # if (combineFormat := wordFormatMap.get(lastWord)):
+                    #     wordSet, wordFormat = combineFormat.getFormat(captionWords)
+                    #     if wordSet and wordFormat:
+                    #         lastWordFormat = None
+                    #         for word in captionWords[:-1]:
+                    #             if word in wordSet:
+                    #                 self._highlightPart(cursor, wordFormat, pos, len(word))
+                    #                 lastWordFormat = wordFormat
+                    #             pos += len(word) + 1
+
+                    #         if lastWordFormat:
+                    #             self._highlightPart(cursor, lastWordFormat, pos, len(lastWord))
+
+                    # if (combineFormat := wordFormatMap.get(lastWord)) and combineFormat.hasSubset(captionWords):
+                    #     lastWordFormat = None
+                    #     for word in captionWords[:-1]:
+                    #         if wordFormat := combineFormat.wordFormats.get(word):
+                    #             self._highlightPart(cursor, wordFormat, pos, len(word))
+                    #             lastWordFormat = wordFormat
+                    #         pos += len(word) + 1
+
+                    #     if lastWordFormat:
+                    #         self._highlightPart(cursor, lastWordFormat, pos, len(lastWord))
+
+                start += len(captionStrip) + padRight + len(separator)
+
+    def _highlightPart(self, cursor: QtGui.QTextCursor, format: QtGui.QTextCharFormat, start: int, length: int):
+        cursor.setPosition(start)
+        cursor.setPosition(start+length, QtGui.QTextCursor.MoveMode.KeepAnchor)
+        cursor.setCharFormat(format)
+
+
+    def update(self):
+        colors: dict[str, str] = dict()
+        formats: dict[str, QtGui.QTextCharFormat] = dict()
+
+        # First insert all focus tags. This is the default color if focus tags don't belong to groups.
+        focusSet = self.ctx.focus.getFocusSet()
+        for focusTag in focusSet:
+            colors[focusTag] = COLOR_FOCUS_DEFAULT
+            formats[focusTag] = self._focusFormat
+
+        # Insert group colors
+        for group in self.ctx.groups.groups:
+            mutedColor, mutedFormat = self._getMuted(group.color) if focusSet else (group.color, group.charFormat)
+
+            for caption in group.captionsExpandWildcards:
+                if caption in focusSet:
+                    colors[caption]  = group.color
+                    formats[caption] = group.charFormat
+                else:
+                    colors[caption]  = mutedColor
+                    formats[caption] = mutedFormat
+
+        # Insert banned color. This will overwrite group colors.
+        bannedColor, bannedFormat = self._getMuted(qtlib.COLOR_BUBBLE_BAN) if focusSet else (qtlib.COLOR_BUBBLE_BAN, self._bannedFormat)
+        bannedFocusColor, bannedFocusFormat = self._getMuted(COLOR_FOCUS_BAN, 1, 1) if focusSet else (qtlib.COLOR_BUBBLE_BAN, self._bannedFormat)
+        for banned in self.ctx.settings.bannedCaptions:
+            if banned in focusSet:
+                colors[banned]  = bannedFocusColor
+                formats[banned] = bannedFocusFormat
+            else:
+                colors[banned]  = bannedColor
+                formats[banned] = bannedFormat
+
+        # Hover color
+        for caption, color in colors.items():
+            if self.ctx.container.isHovered(caption):
+                colors[caption], formats[caption] = self._getHovered(color)
+
+        self._cachedColors = colors
+        self._cachedCharFormats = formats
+
+
+    def updateCombineFormats(self):
+        # Last Word => CombineFormat
+        formatMap = dict[str, CombineFormat]()
+
+        for group in self.ctx.groups.groups:
+            if not group.combineTags:
+                continue
+
+            groupFormat = group.charFormat
+            groupWords = set[str]()
+            groupLastWords = set[str]()
+
+            for caption in group.captionsExpandWildcards:
+                words = [word for word in caption.split(" ") if word]
+                if len(words) < 2:
+                    continue
+
+                groupWords.update(words)
+
+                lastWord = words[-1]
+                groupLastWords.add(lastWord)
+
+                for word in words[:-1]:
+                    combineFormat = formatMap.get(lastWord)
+                    if not combineFormat:
+                        formatMap[lastWord] = combineFormat = CombineFormat(lastWord)
+
+                    combineFormat.wordFormats[word] = groupFormat
+
+                    wordSet = frozenset(words)
+                    #combineFormat.tagSets.add(wordSet)
+                    #combineFormat.tagFormats[wordSet] = groupFormat
+
+            for lastWord in groupLastWords:
+                wordSet = set(groupWords)
+                wordSet.discard(lastWord)
+                formatMap[lastWord].groupFormats.append(CombineFormat.GroupFormat(wordSet, groupFormat))
+
+        # Remove entries with only one word
+        self._cachedCombineFormats = {k: cf for k, cf in formatMap.items() if cf.finalize()}
+
+
+    @Slot()
+    def clearCache(self):
+        self._cachedColors = None
+        self._cachedCharFormats = None
+        self._cachedCombineFormats = None
+
+
+    def _getMuted(self, color: str, mixS=0.22, mixV=0.3):
+        mutedColor = colors.mixBubbleColor(color, mixS, mixV)
+        mutedFormat = QtGui.QTextCharFormat()
+        mutedFormat.setForeground(qtlib.getHighlightColor(mutedColor))
+        return mutedColor, mutedFormat
+
+    def _getHovered(self, color: str):
+        h, s, v = util.get_hsv(color)
+        s = max(0.3, min(1.0, s*0.8))
+        v = max(0.2, min(1.0, v*1.6))
+        hoveredColor = util.hsv_to_rgb(h, s, v)
+
+        hoveredFormat = QtGui.QTextCharFormat()
+        hoveredFormat.setForeground(qtlib.getHighlightColor(hoveredColor))
+        hoveredFormat.setFontUnderline(True)
+
+        return hoveredColor, hoveredFormat
+
+
+
+# One CombineFormat is shared by multiple groups.
+# Retrieved from dict [ Last Word => CombineFormat ]
+# That dict is uses for faster initial lookup, matching the last word.
+class CombineFormat:
+    class GroupFormat:
+        def __init__(self, words: set[str], format: QtGui.QTextCharFormat):
+            self.words = frozenset(words)
+            self.format = format
+
+
+    def __init__(self, lastWord: str):
+        self.wordFormats = dict[str, QtGui.QTextCharFormat]()
+        #self.tagSets = set[frozenset[str]]()
+
+        #self.tagFormats = dict[frozenset[str], QtGui.QTextCharFormat]()
+        #self._tagFormatsSorted = list[tuple[frozenset[str], QtGui.QTextCharFormat]]()
+
+        self.lastWord = lastWord
+        self.groupFormats = list[self.GroupFormat]()
+
+    def finalize(self) -> bool:
+        if len(self.wordFormats) < 2:
+            return False
+
+        # print("CombineFormat Tag Order:")
+        # for k in self.tagFormats.keys():
+        #     print(f"  {k}")
+
+        # self._tagFormatsSorted = sorted(((k, v) for k, v in self.tagFormats.items()), key=lambda item: -len(item[0]))
+        # self.tagFormats = None
+
+        # print("CombineFormat Tag Order (sorted):")
+        # for k, v in self._tagFormatsSorted:
+        #     print(f"  {k}")
+
+
+        self.groupFormats.sort(key=lambda item: -len(item.words))
+        return True
+
+    # def hasSubset(self, captionWords: list[str]) -> bool:
+    #     captionWords = [word for word in captionWords if word]
+    #     for tagSet in self.tagSets:
+    #         print(f"subset test: {tagSet} -> in caption -> {captionWords}")
+    #         if tagSet.issubset(captionWords):
+    #             print("  => True")
+    #             return True
+    #     return False
+
+    # def hasSubset(self, captionWords: list[str]) -> bool:
+    #     captionWords = [word for word in captionWords if word]
+    #     for tagSet, format in self._tagFormatsSorted:
+    #         print(f"subset test: {tagSet} -> in caption -> {captionWords}")
+    #         if tagSet.issubset(captionWords):
+    #             print("  => True")
+    #             return True
+    #     return False
+
+
+    # # Find group with longest match (maximum number of 'captionWords' in group tags)
+    # def getFormat(self, captionWords: list[str]):
+    #     captionWords = [word for word in captionWords if word]
+
+    #     # TODO: Return set with words in group
+
+    #     for tagSet, format in self._tagFormatsSorted:
+    #         print(f"subset test: {tagSet} -> in caption -> {captionWords}")
+    #         if tagSet.issubset(captionWords):
+    #             print("  => True")
+    #             return tagSet, format
+
+    #     return None, None
+
+
+    # Find group with longest match (maximum number of 'captionWords' in group tags)
+    def getGroupFormat(self, captionWords: list[str]):
+        captionWords = [word for word in captionWords if word and word != self.lastWord]
+        if not captionWords:
+            return None
+
+        maxWords = 0
+        bestFormat = None
+
+        for groupFormat in self.groupFormats:
+            intersection = groupFormat.words.intersection(captionWords)
+            # Complete match: All caption words are members of the same group
+            if len(intersection) == len(captionWords):
+                return groupFormat
+
+            if len(intersection) > maxWords:
+                maxWords = len(intersection)
+                bestFormat = groupFormat
+
+        # if bestFormat:
+        #     print(f"for caption: {captionWords}  => best group: {bestFormat.words}")
+        return bestFormat

--- a/caption/caption_highlight.py
+++ b/caption/caption_highlight.py
@@ -17,13 +17,16 @@ class CaptionHighlight:
 
         self._cachedColors: dict[str, str] | None = None
         self._cachedCharFormats: dict[str, QtGui.QTextCharFormat] | None = None
-        self._cachedCombineFormats: dict[str, CombineFormat] | None = None
+        self._cachedMatcherNode: MatcherNode | None = None
 
         self._bannedFormat = QtGui.QTextCharFormat()
         self._bannedFormat.setForeground(QtGui.QColor.fromHsvF(0, 0, 0.5))
 
         self._focusFormat = QtGui.QTextCharFormat()
         self._focusFormat.setForeground(qtlib.getHighlightColor(COLOR_FOCUS_DEFAULT))
+
+        self._hoverFormat = QtGui.QTextCharFormat()
+        self._hoverFormat.setFontUnderline(True)
 
 
     @property
@@ -39,17 +42,17 @@ class CaptionHighlight:
         return self._cachedCharFormats
 
     @property
-    def combineFormats(self) -> dict[str, CombineFormat]:
-        if not self._cachedCombineFormats:
-            self.updateCombineFormats()
-        return self._cachedCombineFormats
+    def matchNode(self) -> MatcherNode:
+        if not self._cachedMatcherNode:
+            self.updateMatcherNode()
+        return self._cachedMatcherNode
 
 
     def highlight(self, text: str, separator: str, txtWidget: QtWidgets.QPlainTextEdit):
         separator = separator.strip()
 
         formats = self.charFormats
-        wordFormatMap = self.combineFormats
+        matchNode = self.matchNode
 
         with QSignalBlocker(txtWidget):
             cursor = txtWidget.textCursor()
@@ -66,47 +69,16 @@ class CaptionHighlight:
                 if format := formats.get(captionStrip):
                     self._highlightPart(cursor, format, start, len(captionStrip))
                 elif self.ctx.container.isHovered(captionStrip):
-                    format = QtGui.QTextCharFormat()
-                    format.setFontUnderline(True)
-                    self._highlightPart(cursor, format, start, len(captionStrip))
-
-                # Try highlighting combined words
+                    self._highlightPart(cursor, self._hoverFormat, start, len(captionStrip))
                 else:
+                    # Try highlighting combined words
                     captionWords = captionStrip.split(" ")
-                    lastWord = captionWords[-1]
-                    pos = start
-
-                    if (combineFormat := wordFormatMap.get(lastWord)) and (groupFormat := combineFormat.getGroupFormat(captionWords)):
-                        for word in captionWords[:-1]:
-                            if word in groupFormat.words:
-                                self._highlightPart(cursor, groupFormat.format, pos, len(word))
+                    if matcherFormats := matchNode.match(captionWords):
+                        pos = start
+                        for i, word in enumerate(captionWords):
+                            if format := matcherFormats.get(i):
+                                self._highlightPart(cursor, format, pos, len(word))
                             pos += len(word) + 1
-
-                        self._highlightPart(cursor, groupFormat.format, pos, len(lastWord))
-
-                    # if (combineFormat := wordFormatMap.get(lastWord)):
-                    #     wordSet, wordFormat = combineFormat.getFormat(captionWords)
-                    #     if wordSet and wordFormat:
-                    #         lastWordFormat = None
-                    #         for word in captionWords[:-1]:
-                    #             if word in wordSet:
-                    #                 self._highlightPart(cursor, wordFormat, pos, len(word))
-                    #                 lastWordFormat = wordFormat
-                    #             pos += len(word) + 1
-
-                    #         if lastWordFormat:
-                    #             self._highlightPart(cursor, lastWordFormat, pos, len(lastWord))
-
-                    # if (combineFormat := wordFormatMap.get(lastWord)) and combineFormat.hasSubset(captionWords):
-                    #     lastWordFormat = None
-                    #     for word in captionWords[:-1]:
-                    #         if wordFormat := combineFormat.wordFormats.get(word):
-                    #             self._highlightPart(cursor, wordFormat, pos, len(word))
-                    #             lastWordFormat = wordFormat
-                    #         pos += len(word) + 1
-
-                    #     if lastWordFormat:
-                    #         self._highlightPart(cursor, lastWordFormat, pos, len(lastWord))
 
                 start += len(captionStrip) + padRight + len(separator)
 
@@ -158,53 +130,28 @@ class CaptionHighlight:
         self._cachedCharFormats = formats
 
 
-    def updateCombineFormats(self):
-        # Last Word => CombineFormat
-        formatMap = dict[str, CombineFormat]()
+    def updateMatcherNode(self):
+        root = MatcherNode("")
 
         for group in self.ctx.groups.groups:
-            if not group.combineTags:
-                continue
-
             groupFormat = group.charFormat
-            groupWords = set[str]()
-            groupLastWords = set[str]()
 
             for caption in group.captionsExpandWildcards:
                 words = [word for word in caption.split(" ") if word]
-                if len(words) < 2:
-                    continue
 
-                groupWords.update(words)
+                node = root
+                for word in reversed(words):
+                    node = node[word]
+                node.format = groupFormat
 
-                lastWord = words[-1]
-                groupLastWords.add(lastWord)
-
-                for word in words[:-1]:
-                    combineFormat = formatMap.get(lastWord)
-                    if not combineFormat:
-                        formatMap[lastWord] = combineFormat = CombineFormat(lastWord)
-
-                    combineFormat.wordFormats[word] = groupFormat
-
-                    wordSet = frozenset(words)
-                    #combineFormat.tagSets.add(wordSet)
-                    #combineFormat.tagFormats[wordSet] = groupFormat
-
-            for lastWord in groupLastWords:
-                wordSet = set(groupWords)
-                wordSet.discard(lastWord)
-                formatMap[lastWord].groupFormats.append(CombineFormat.GroupFormat(wordSet, groupFormat))
-
-        # Remove entries with only one word
-        self._cachedCombineFormats = {k: cf for k, cf in formatMap.items() if cf.finalize()}
+        self._cachedMatcherNode = root
 
 
     @Slot()
     def clearCache(self):
         self._cachedColors = None
         self._cachedCharFormats = None
-        self._cachedCombineFormats = None
+        self._cachedMatcherNode = None
 
 
     def _getMuted(self, color: str, mixS=0.22, mixV=0.3):
@@ -227,98 +174,66 @@ class CaptionHighlight:
 
 
 
-# One CombineFormat is shared by multiple groups.
-# Retrieved from dict [ Last Word => CombineFormat ]
-# That dict is uses for faster initial lookup, matching the last word.
-class CombineFormat:
-    class GroupFormat:
-        def __init__(self, words: set[str], format: QtGui.QTextCharFormat):
-            self.words = frozenset(words)
-            self.format = format
+class MatcherNode:
+    def __init__(self, name: str):
+        self.name = name
+        self.children = dict[str, MatcherNode]()
+        self.format: QtGui.QTextCharFormat | None = None
+
+    def __setitem__(self, key: str, node: MatcherNode):
+        self.children[key] = node
+
+    def __getitem__(self, key: str) -> MatcherNode:
+        node = self.children.get(key)
+        if node is None:
+            self.children[key] = node = MatcherNode(key)
+        return node
 
 
-    def __init__(self, lastWord: str):
-        self.wordFormats = dict[str, QtGui.QTextCharFormat]()
-        #self.tagSets = set[frozenset[str]]()
+    def __str__(self) -> str:
+        return f"Node[{self.name}]"
 
-        #self.tagFormats = dict[frozenset[str], QtGui.QTextCharFormat]()
-        #self._tagFormatsSorted = list[tuple[frozenset[str], QtGui.QTextCharFormat]]()
-
-        self.lastWord = lastWord
-        self.groupFormats = list[self.GroupFormat]()
-
-    def finalize(self) -> bool:
-        if len(self.wordFormats) < 2:
-            return False
-
-        # print("CombineFormat Tag Order:")
-        # for k in self.tagFormats.keys():
-        #     print(f"  {k}")
-
-        # self._tagFormatsSorted = sorted(((k, v) for k, v in self.tagFormats.items()), key=lambda item: -len(item[0]))
-        # self.tagFormats = None
-
-        # print("CombineFormat Tag Order (sorted):")
-        # for k, v in self._tagFormatsSorted:
-        #     print(f"  {k}")
+    def printTree(self, level: int = 0):
+        indent = "  " * level
+        for k, v in self.children.items():
+            print(f"{indent}{k}:")
+            v.printTree(level+1)
 
 
-        self.groupFormats.sort(key=lambda item: -len(item.words))
-        return True
+    class MatcherStackEntry:
+        def __init__(self, node: MatcherNode, index: int):
+            self.node = node
+            self.index = index
 
-    # def hasSubset(self, captionWords: list[str]) -> bool:
-    #     captionWords = [word for word in captionWords if word]
-    #     for tagSet in self.tagSets:
-    #         print(f"subset test: {tagSet} -> in caption -> {captionWords}")
-    #         if tagSet.issubset(captionWords):
-    #             print("  => True")
-    #             return True
-    #     return False
+    def match(self, words: list[str]) -> dict[int, QtGui.QTextCharFormat]:
+        node = self
+        stack = list[self.MatcherStackEntry]()
+        formats = dict[int, QtGui.QTextCharFormat]()
 
-    # def hasSubset(self, captionWords: list[str]) -> bool:
-    #     captionWords = [word for word in captionWords if word]
-    #     for tagSet, format in self._tagFormatsSorted:
-    #         print(f"subset test: {tagSet} -> in caption -> {captionWords}")
-    #         if tagSet.issubset(captionWords):
-    #             print("  => True")
-    #             return True
-    #     return False
+        def handleLeaf(node: MatcherNode, child: MatcherNode, index: int, override=False) -> MatcherNode:
+            if child.format:
+                for entry in stack:
+                    if override or (entry.index not in formats):
+                        formats[entry.index] = child.format
+                formats[index] = child.format
 
-
-    # # Find group with longest match (maximum number of 'captionWords' in group tags)
-    # def getFormat(self, captionWords: list[str]):
-    #     captionWords = [word for word in captionWords if word]
-
-    #     # TODO: Return set with words in group
-
-    #     for tagSet, format in self._tagFormatsSorted:
-    #         print(f"subset test: {tagSet} -> in caption -> {captionWords}")
-    #         if tagSet.issubset(captionWords):
-    #             print("  => True")
-    #             return tagSet, format
-
-    #     return None, None
+            if child.children:
+                stack.append(self.MatcherStackEntry(child, index))
+                return child
+            return node
 
 
-    # Find group with longest match (maximum number of 'captionWords' in group tags)
-    def getGroupFormat(self, captionWords: list[str]):
-        captionWords = [word for word in captionWords if word and word != self.lastWord]
-        if not captionWords:
-            return None
+        for i in range(len(words)-1, -1, -1):
+            word = words[i]
+            if not word:
+                continue
 
-        maxWords = 0
-        bestFormat = None
+            if child := node.children.get(word):
+                node = handleLeaf(node, child, i, True)
 
-        for groupFormat in self.groupFormats:
-            intersection = groupFormat.words.intersection(captionWords)
-            # Complete match: All caption words are members of the same group
-            if len(intersection) == len(captionWords):
-                return groupFormat
+            # Search for a different transition by unwinding stack
+            elif len(stack) > 1 and (child := stack[-2].node.children.get(word)):
+                stack.pop()
+                node = handleLeaf(stack[-1].node, child, i)
 
-            if len(intersection) > maxWords:
-                maxWords = len(intersection)
-                bestFormat = groupFormat
-
-        # if bestFormat:
-        #     print(f"for caption: {captionWords}  => best group: {bestFormat.words}")
-        return bestFormat
+        return formats

--- a/caption/caption_menu.py
+++ b/caption/caption_menu.py
@@ -2,6 +2,7 @@ from enum import Enum
 from PySide6 import QtWidgets
 from PySide6.QtCore import Signal, Slot
 from config import Config
+from .caption_context import CaptionContext
 
 
 class RulesLoadMode(Enum):
@@ -14,11 +15,9 @@ class CaptionMenu(QtWidgets.QMenu):
     previewToggled = Signal(bool)
 
 
-    def __init__(self, parent, context):
+    def __init__(self, parent, context: CaptionContext):
         super().__init__(parent)
-
-        from .caption_container import CaptionContext
-        self.ctx: CaptionContext = context
+        self.ctx = context
 
         self._build()
         self.aboutToShow.connect(self._updateMenu)

--- a/caption/caption_preset.py
+++ b/caption/caption_preset.py
@@ -24,6 +24,7 @@ class CaptionPreset:
         self.sortCaptions: bool     = True
 
         self.groups         = list[CaptionPresetGroup]()
+        self.wildcards      = dict[str, list[str]]()
         self.conditionals   = list[CaptionPresetConditional]()
         self.searchReplace  = list[tuple[str, str]]()
         self.banned         = list[str]()
@@ -51,6 +52,7 @@ class CaptionPreset:
             "remove_duplicates": self.removeDuplicates,
             "sort_captions": self.sortCaptions,
             "groups": groupData,
+            "wildcards": self.wildcards,
             "conditionals": conditionals,
             "search_replace": self.searchReplace,
             "banned": self.banned
@@ -75,6 +77,7 @@ class CaptionPreset:
         self.sortCaptions       = data.get("sort_captions", True)
         self.searchReplace      = data.get("search_replace", [])
         self.banned             = data.get("banned", [])
+        self.wildcards          = data.get("wildcards", {})
 
         self.groups.clear()
         for group in data.get("groups", []):

--- a/caption/caption_settings.py
+++ b/caption/caption_settings.py
@@ -176,7 +176,7 @@ class CaptionSettings(CaptionTab):
 
     @Slot()
     def banSelectedCaption(self):
-        caption = self.ctx.container.getSelectedCaption()
+        caption = self.ctx.text.getSelectedCaption()
         self.addBannedCaption(caption)
 
 

--- a/caption/caption_tab.py
+++ b/caption/caption_tab.py
@@ -5,7 +5,7 @@ class CaptionTab(QtWidgets.QWidget):
     def __init__(self, context):
         super().__init__()
 
-        from .caption_container import CaptionContext
+        from .caption_context import CaptionContext
         self.ctx: CaptionContext = context
 
 

--- a/caption/caption_text.py
+++ b/caption/caption_text.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+from PySide6 import QtWidgets, QtGui
+from PySide6.QtCore import Qt, Signal, Slot, QSignalBlocker, QTimer
+from lib.util import stripCountPadding
+
+
+class CaptionTextEdit(QtWidgets.QPlainTextEdit):
+    needsRulesApplied = Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.separator = ", "
+
+
+    def getCaption(self) -> str:
+        return self.toPlainText()
+
+    def setCaption(self, text):
+        self.setPlainText(text)
+        self.moveCursor(QtGui.QTextCursor.MoveOperation.End)
+
+
+    @Slot()
+    def appendToCaption(self, text: str):
+        caption = self.toPlainText()
+        if caption:
+            caption += self.separator
+        caption += text
+
+        self.setCaption(caption)
+        self.needsRulesApplied.emit()
+
+    def toggleCaption(self, caption: str, removeWords: set[str]|None):
+        caption = caption.strip()
+        captions = []
+        removed = False
+
+        # lastWord = ""
+        # if removeWords:
+        #     print(f"removeWords: {removeWords}")
+        #     lastWord = caption.rsplit(" ", 1)[-1]
+
+        text = self.toPlainText()
+        if text:
+            for current in text.split(self.separator.strip()):
+                current = current.strip()
+                if caption == current:
+                    removed = True
+                # elif removeWords and current.endswith(lastWord):
+                #     # All removeWords need to exist in 'current'
+                #     # TODO: Still buggy! Removing from other groups when removeWords has one word.
+                #     currentWords = [word for word in current.split(" ")]
+                #     if not removeWords.issubset(currentWords):
+                #         captions.append(current)
+                #         continue
+
+                #     current = " ".join(word for word in currentWords if word not in removeWords)
+                #     if current != lastWord:
+                #         captions.append(current)
+                #     removed = True
+                else:
+                    captions.append(current)
+
+        if not removed:
+            captions.append(caption)
+
+        self.setCaption( self.separator.join(captions) )
+        self.needsRulesApplied.emit()
+
+    @Slot()
+    def removeCaption(self, index: int):
+        text = self.toPlainText()
+        sepStrip = self.separator.strip()
+        captions = [c.strip() for c in text.split(sepStrip)]
+        del captions[index]
+        self.setCaption( self.separator.join(captions) )
+
+
+    def getSelectedCaption(self) -> str:
+        cursorPos = self.textCursor().position()
+        return self._getCaptionAtCursor(cursorPos)[0]
+
+    def _getCaptionAtCursor(self, cursorPos: int) -> tuple[str, int]:
+        text = self.toPlainText()
+        return self.getCaptionAtCursor(text, self.separator, cursorPos)
+
+    @staticmethod
+    def getCaptionAtCursor(text: str, separator: str, cursorPos: int) -> tuple[str, int]:
+        sepStrip = separator.strip()
+        accumulatedLength = 0
+        for i, caption in enumerate(text.split(sepStrip)):
+            accumulatedLength += len(caption) + len(sepStrip)
+            if cursorPos < accumulatedLength:
+                return caption.strip(), i
+
+        return "", -1
+
+    @Slot()
+    def selectCaption(self, index: int):
+        text = self.toPlainText()
+        sepStrip, sepSpaceL, sepSpaceR = stripCountPadding(self.separator)
+
+        accumulatedLength = 0
+        splitCaptions = text.split(sepStrip)
+        for i, caption in enumerate(splitCaptions):
+            if i != index:
+                accumulatedLength += len(caption) + len(sepStrip)
+                continue
+
+            capStrip, capSpaceL, capSpaceR = stripCountPadding(caption)
+            offsetL = min(capSpaceL, sepSpaceR) if i > 0 else 0
+            offsetR = min(capSpaceR, sepSpaceL) if i < len(splitCaptions)-1 else 0
+
+            start = accumulatedLength + offsetL
+            end   = accumulatedLength + len(caption) - offsetR
+
+            cursor = self.textCursor()
+            cursor.setPosition(start, QtGui.QTextCursor.MoveMode.MoveAnchor)
+            cursor.setPosition(end, QtGui.QTextCursor.MoveMode.KeepAnchor)
+            self.setTextCursor(cursor)
+
+    @Slot()
+    def moveCaptionSelection(self, offset: int, offsetLine: int):
+        cursor = self.textCursor()
+        if offsetLine != 0:
+            moveLineDir = QtGui.QTextCursor.MoveOperation.Up if offsetLine < 0 else QtGui.QTextCursor.MoveOperation.Down
+            cursor.movePosition(moveLineDir, QtGui.QTextCursor.MoveMode.MoveAnchor)
+
+        index = self._getCaptionAtCursor(cursor.position())[1]
+        index = max(0, index+offset)
+        self.selectCaption(index)
+
+    @Slot()
+    def removeSelectedCaption(self):
+        cursor = self.textCursor()
+        index = self._getCaptionAtCursor(cursor.position())[1]
+        self.removeCaption(index)
+
+        # Set cursor to start of next caption
+        self.selectCaption(index)
+        cursor = self.textCursor()
+        cursor.setPosition(cursor.selectionStart())
+        self.setTextCursor(cursor)
+
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent):
+        if event.modifiers() & Qt.KeyboardModifier.AltModifier:
+            move = None
+            match event.key():
+                case Qt.Key.Key_Alt:    move = (0, 0)
+                case Qt.Key.Key_Left:   move = (-1, 0)
+                case Qt.Key.Key_Right:  move = (1, 0)
+                case Qt.Key.Key_Up:     move = (0, -1)
+                case Qt.Key.Key_Down:   move = (0, 1)
+
+                case Qt.Key.Key_Delete:
+                    event.accept()
+                    self.removeSelectedCaption()
+                    return
+
+            if move is not None:
+                event.accept()
+                self.moveCaptionSelection(move[0], move[1])
+                return
+
+        super().keyPressEvent(event)
+
+
+    def dropEvent(self, event: QtGui.QDropEvent):
+        with QSignalBlocker(self):
+            super().dropEvent(event)
+
+        # Don't remove buttons from CaptionControlGroup
+        event.setDropAction(Qt.DropAction.CopyAction)
+
+        # Postpone updates when dropping so they don't interfere with ongoing drag operations in ReorderWidget.
+        # But don't postpone normal updates to prevent flickering.
+        QTimer.singleShot(0, self.textChanged.emit)

--- a/caption/caption_text.py
+++ b/caption/caption_text.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 from PySide6 import QtWidgets, QtGui
 from PySide6.QtCore import Qt, Slot, QSignalBlocker, QTimer
 from lib.util import stripCountPadding
+from .caption_context import CaptionContext
 
 
 class CaptionTextEdit(QtWidgets.QPlainTextEdit):
-    def __init__(self, context):
+    def __init__(self, context: CaptionContext):
         super().__init__()
-
-        from .caption_container import CaptionContext
-        self.ctx: CaptionContext = context
+        self.ctx = context
 
         self.separator = self.ctx.settings.separator
         self.ctx.separatorChanged.connect(self._onSeparatorChanged)
@@ -109,8 +108,8 @@ class CaptionTextEdit(QtWidgets.QPlainTextEdit):
             end   = accumulatedLength + len(caption) - offsetR
 
             cursor = self.textCursor()
-            cursor.setPosition(start, QtGui.QTextCursor.MoveMode.MoveAnchor)
-            cursor.setPosition(end, QtGui.QTextCursor.MoveMode.KeepAnchor)
+            cursor.setPosition(end, QtGui.QTextCursor.MoveMode.MoveAnchor)
+            cursor.setPosition(start, QtGui.QTextCursor.MoveMode.KeepAnchor)
             self.setTextCursor(cursor)
 
     @Slot()

--- a/caption/caption_wildcard.py
+++ b/caption/caption_wildcard.py
@@ -1,0 +1,115 @@
+import re
+from itertools import product
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt, Slot
+import lib.qtlib as qtlib
+
+
+WildcardDict = dict[str, list[str]]
+
+PATTERN_WILDCARD = re.compile( r'({{[^}]+}})' )
+
+
+class WildcardWindow(QtWidgets.QDialog):
+    def __init__(self, parent: QtWidgets.QWidget, wildcards: WildcardDict) -> None:
+        super().__init__(parent)
+        self.wildcards = wildcards
+
+        self._build()
+        self.fromDict()
+
+        self.setWindowModality(Qt.WindowModality.ApplicationModal)
+        self.setWindowTitle("Setup Wildcards")
+        self.resize(600, 400)
+
+    def _build(self):
+        infoLayout = QtWidgets.QHBoxLayout()
+        infoLayout.addWidget(QtWidgets.QLabel("One per line. Example:"), 0)
+
+        lblExample = QtWidgets.QLabel("colors: blue, green, black, white")
+        qtlib.setMonospace(lblExample)
+        infoLayout.addWidget(lblExample, 1)
+
+        layout = QtWidgets.QGridLayout(self)
+
+        row = 0
+        layout.addLayout(infoLayout, row, 0, 1, 3)
+
+        row += 1
+        layout.addWidget(QtWidgets.QLabel("Use in group-tags as \"{{colors}} pants\"."))
+
+        row += 1
+        layout.setRowStretch(row, 1)
+
+        self.txtWildcards = QtWidgets.QPlainTextEdit()
+        qtlib.setMonospace(self.txtWildcards)
+        layout.addWidget(self.txtWildcards, row, 0, 1, 3)
+
+        row += 1
+        btnSave = QtWidgets.QPushButton("Save")
+        btnSave.clicked.connect(self._acceptWildcards)
+        btnSave.clicked.connect(self.accept)
+        layout.addWidget(btnSave, row, 0)
+
+        btnReload = QtWidgets.QPushButton("Reload")
+        btnReload.clicked.connect(self.fromDict)
+        layout.addWidget(btnReload, row, 1)
+
+        btnCancel = QtWidgets.QPushButton("Cancel")
+        btnCancel.clicked.connect(self.reject)
+        layout.addWidget(btnCancel, row, 2)
+
+        self.setLayout(layout)
+
+    @Slot()
+    def fromDict(self):
+        self.txtWildcards.clear()
+        lines = list[str]()
+        for name, tags in self.wildcards.items():
+            tags = ", ".join(tags)
+            lines.append(f"{name}: {tags}")
+        self.txtWildcards.setPlainText("\n".join(lines))
+
+    def toDict(self) -> WildcardDict:
+        wildcards = WildcardDict()
+        lines = self.txtWildcards.toPlainText().splitlines()
+        for line in lines:
+            name, *tags = line.split(":")
+            name = name.strip()
+            if name and tags:
+                wildcards[name] = [tag for t in tags[0].split(",") if (tag := t.strip())]
+
+        return wildcards
+
+    @Slot()
+    def _acceptWildcards(self):
+        self.wildcards = self.toDict()
+
+
+
+def expandWildcards(tag: str, wildcards: WildcardDict) -> list[str]:
+    wildcardPos = list[int]()
+    wildcardTags = list[list[str]]()
+
+    parts = PATTERN_WILDCARD.split(tag)
+    if len(parts) == 1:
+        return parts
+
+    for i, part in enumerate(parts):
+        if part.startswith("{{") and part.endswith("}}"):
+            part = part.strip("{}")
+            if wcTags := wildcards.get(part):
+                wildcardPos.append(i)
+                wildcardTags.append(wcTags)
+
+    if not wildcardPos:
+        return [tag]
+
+    tags = list[str]()
+    for wildcardVals in product(*wildcardTags):
+        newParts = list[str](parts)
+        for i, val in enumerate(wildcardVals):
+            newParts[wildcardPos[i]] = val
+        tags.append("".join(newParts))
+
+    return tags

--- a/caption/caption_wildcard.py
+++ b/caption/caption_wildcard.py
@@ -26,7 +26,7 @@ class WildcardWindow(QtWidgets.QDialog):
         infoLayout = QtWidgets.QHBoxLayout()
         infoLayout.addWidget(QtWidgets.QLabel("One per line. Example:"), 0)
 
-        lblExample = QtWidgets.QLabel("colors: blue, green, black, white")
+        lblExample = QtWidgets.QLabel("color: blue, green, black, white")
         qtlib.setMonospace(lblExample)
         infoLayout.addWidget(lblExample, 1)
 
@@ -36,7 +36,7 @@ class WildcardWindow(QtWidgets.QDialog):
         layout.addLayout(infoLayout, row, 0, 1, 3)
 
         row += 1
-        layout.addWidget(QtWidgets.QLabel("Use in group-tags as \"{{colors}} pants\"."))
+        layout.addWidget(QtWidgets.QLabel("Use in group-tags as \"{{color}} pants\"."), row, 0, 1, 3)
 
         row += 1
         layout.setRowStretch(row, 1)

--- a/lib/colors.py
+++ b/lib/colors.py
@@ -1,0 +1,10 @@
+from . import util, qtlib
+
+
+BUBBLE_BLACK_H, BUBBLE_BLACK_S, BUBBLE_BLACK_V = util.get_hsv(qtlib.COLOR_BUBBLE_BLACK)
+
+def mixBubbleColor(destColor: str, mixS: float, mixV: float) -> str:
+    destH, destS, destV = util.get_hsv(destColor)
+    s = BUBBLE_BLACK_S + (destS - BUBBLE_BLACK_S) * mixS
+    v = BUBBLE_BLACK_V + (destV - BUBBLE_BLACK_V) * mixV
+    return util.hsv_to_rgb(destH, s, v)

--- a/lib/util.py
+++ b/lib/util.py
@@ -41,6 +41,17 @@ def isValidColor(color):
     return validColorPattern.match(color) is not None
 
 
+def stripCountPadding(text: str) -> tuple[str, int, int]:
+    textStrip = text.lstrip()
+    padLeft = len(text) - len(textStrip)
+
+    textStrip = textStrip.rstrip()
+    padRight = len(text) - padLeft - len(textStrip)
+
+    return textStrip, padLeft, padRight
+
+
+
 class Singleton(type):
     _instances = {}
     def __call__(cls, *args, **kwargs):

--- a/stats/stats_tags.py
+++ b/stats/stats_tags.py
@@ -99,7 +99,7 @@ class TagStats(QtWidgets.QWidget):
         if not captionWin:
             return
 
-        self.model.updateColors(captionWin.ctx.groups.getCaptionCharFormats())
+        self.model.updateColors(captionWin.ctx.highlight.charFormats)
         if not self._captionSlotConnected:
             captionWin.ctx.controlUpdated.connect(self.reloadColors)
             self._captionSlotConnected = True
@@ -374,8 +374,9 @@ class TagTableView(QtWidgets.QTableView):
     @Slot()
     def _addTags(self):
         if captionWin := getCaptionWindow(self.tab, self):
+            textField = captionWin.ctx.text
             for tag in self.selectedTags():
-                captionWin.appendToCaption(tag)
+                textField.appendToCaption(tag)
 
             # Not needed, but will connect the update signal
             self.captionRulesChanged.emit()


### PR DESCRIPTION
Added wildcards for group-buttons. When used like `{{color}} shirt`, the wildcard variable will expand to all defined values and the group will act as if containing all tags for `blue shirt`, `red shirt`, `black shirt` etc. without using all the space.
Clicking a group-button with wildcards will open a menu with a list of expanded values.
Wildcards can be edited in the Groups tab.

Improved highlighting of combined tags in Caption Window and Batch Rules.
Group buttons support toggling of combined tags: This allows for easier removal of tags from combined tags and works better with "Auto Apply" enabled for rules.

Caption Rules:
- Combine additional tags with already combined tags.
- Sort combined tags.
- Changed order of filters: Removal of duplicates and subsets now happens after sorting and combining. If relevant to the group setup, this gives tags a chance to be combined with other tags before being removed.

Caption Groups:
- Added menu per group with option for creating new group above selected group.
- Added preview of tag-suffixes which will be combined.
- Display bold text for mutual exclusivity when anything other than "Disabled" is selected.

Caption Text:
- Added keyboard shortcuts for navigating and selecting tags inside the text field:
  - ALT: Select current tag
  - ALT + Arrow Keys: Navigate tags
  - ALT + Delete: Delete current tag
- Clicking a bubble will also select the respective tag.

Caption Generate: Improved handling of existing captions when generation finishes while another image is active, considering Append/Prepend.

Batch Rules: Moved preset load/clear buttons into a menu, so they're accessible when the Group or Conditionals subtab is active.

Fix issue with group-button selection state when opening a new image tab.
Fix skewed layout in Caption Conditionals.
Refactor Caption Text and Caption Context.